### PR TITLE
fixed link from k8s.gcr.io to registry.k8s.io in  lib.rs

### DIFF
--- a/crates/wagi-provider/src/lib.rs
+++ b/crates/wagi-provider/src/lib.rs
@@ -187,7 +187,7 @@ impl GenericProvider for WagiProvider {
         container: &kubelet::container::Container,
     ) -> anyhow::Result<()> {
         if let Some(image) = container.image()? {
-            if image.whole().starts_with("k8s.gcr.io/kube-proxy") {
+            if image.whole().starts_with("registry.k8s.io/kube-proxy") {
                 return Err(anyhow::anyhow!("Cannot run kube-proxy"));
             }
         }


### PR DESCRIPTION
This PR fixes [Umbrella Issue] Migrate CNCF Ecosystem projects from k8s.gcr.io to registry.k8s.io
https://github.com/kubernetes/k8s.io/issues/4780